### PR TITLE
Fix #9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtractor",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "String extraction for i18n",
   "main": "lib/index.js",
   "scripts": {

--- a/src/writePo.js
+++ b/src/writePo.js
@@ -1,14 +1,28 @@
 import gettextParser from 'gettext-parser';
 
 export default function(input, options) {
-    let strings = {};
+    let translationObj = {
+        translations: {
+            '': {}
+        }
+    };
 
     input.forEach(entry => {
         const reference = entry.loc
                         .map(loc => `${loc.path}:${loc.line}`)
                         .join('\n');
 
-        strings[entry.msgid] = {
+        let contextObj;
+        if (entry.msgctxt) {
+            if (!translationObj['translations'][entry.msgctxt]) {
+                translationObj['translations'][entry.msgctxt ] = {};
+            }
+            contextObj = translationObj['translations'][entry.msgctxt];
+        } else {
+            contextObj = translationObj['translations'][''];
+        }
+
+        contextObj[entry.msgid] = {
             msgctxt: entry.msgctxt,
             msgid: entry.msgid,
             msgid_plural: entry.msgid_plural,
@@ -17,9 +31,5 @@ export default function(input, options) {
         };
     });
 
-    return gettextParser.po.compile(Object.assign({
-        translations: {
-            "": strings
-        }
-    }, options));
+    return gettextParser.po.compile(Object.assign({}, translationObj, options));
 }

--- a/test/po/test.js
+++ b/test/po/test.js
@@ -25,6 +25,25 @@ describe('xtractor.writePo() -- pluralization', function() {
                         line: 5
                     }
                 ]
+            },
+            {
+                msgid: 'Safe mode alert!',
+                loc: [
+                    {
+                        path: __dirname + '/fixture.js',
+                        line: 10
+                    }
+                ]
+            },
+            {
+                msgid: 'Safe mode alert!',
+                msgctxt: 'settings',
+                loc: [
+                    {
+                        path: __dirname + '/fixture.js',
+                        line: 13
+                    }
+                ]
             }
         ];
 
@@ -43,6 +62,15 @@ msgstr[1] ""
 #: ${__dirname}/fixture.js:3
 #: ${__dirname}/otherfile.js:5
 msgid "Test string"
+msgstr ""
+
+#: ${__dirname}/fixture.js:10
+msgid "Safe mode alert!"
+msgstr ""
+
+#: ${__dirname}/fixture.js:13
+msgid "Safe mode alert!"
+msgctxt "settings"
 msgstr ""`;
 
         var output = writePo(input, {

--- a/test/po/test.js
+++ b/test/po/test.js
@@ -69,8 +69,8 @@ msgid "Safe mode alert!"
 msgstr ""
 
 #: ${__dirname}/fixture.js:13
-msgid "Safe mode alert!"
 msgctxt "settings"
+msgid "Safe mode alert!"
 msgstr ""`;
 
         var output = writePo(input, {


### PR DESCRIPTION
Fixes #9. Due to incorrect documentation (https://github.com/andris9/gettext-parser/pull/17) we placed strings with non-default context incorrectly