### PR TITLE
Smartling string context

### DIFF
--- a/src/StringStore.js
+++ b/src/StringStore.js
@@ -20,10 +20,10 @@ export default class StringStore {
         }
 
         entry.msgid = preprocess(entry.msgid);
-        if (this._store[[entry.msgid, entry.msgctxt]]) {
-            this._store[[entry.msgid, entry.msgctxt]].loc = this._store[[entry.msgid, entry.msgctxt]].loc.concat(entry.loc);
+        if (this._store[[entry.msgid, entry.ctxtForTranslator]]) {
+            this._store[[entry.msgid, entry.ctxtForTranslator]].loc = this._store[[entry.msgid, entry.ctxtForTranslator]].loc.concat(entry.loc);
         } else {
-            this._store[[entry.msgid, entry.msgctxt]] = entry;
+            this._store[[entry.msgid, entry.ctxtForTranslator]] = entry;
         }
     }
 

--- a/src/parsers/js.js
+++ b/src/parsers/js.js
@@ -63,7 +63,7 @@ export default function parseAndExtract(source, filepath, markers, store) {
             const {callee: {name, type}} = node;
 
             if ((type === 'Identifier' && markers.indexOf(name) !== -1) || matchesMarkers(path.get('callee'), markers)) {
-                let msgid, msgctxt, msgid_plural;
+                let msgid, ctxtForTranslator, msgid_plural;
 
                 //TODO: handle unexpected args
                 if (node.arguments.length === 1) {
@@ -72,7 +72,7 @@ export default function parseAndExtract(source, filepath, markers, store) {
                 } else if (node.arguments.length === 2) {
                     // singular, with context
                     msgid = extractString(node.arguments[0]);
-                    msgctxt = extractString(node.arguments[1]);
+                    ctxtForTranslator = extractString(node.arguments[1]);
                 } else if (node.arguments.length === 3) {
                     // plural, no context
                     msgid = extractString(node.arguments[0]);
@@ -81,7 +81,7 @@ export default function parseAndExtract(source, filepath, markers, store) {
                     // plural, with context
                     msgid = extractString(node.arguments[0]);
                     msgid_plural = extractString(node.arguments[1]);
-                    msgctxt = extractString(node.arguments[3])
+                    ctxtForTranslator = extractString(node.arguments[3])
                 }
                 if (msgid) {
                     // construct the entry first
@@ -95,8 +95,8 @@ export default function parseAndExtract(source, filepath, markers, store) {
                     if (msgid_plural) {
                         entryToAdd.msgid_plural = msgid_plural;
                     }
-                    if (msgctxt) {
-                        entryToAdd.msgctxt = msgctxt;
+                    if (ctxtForTranslator) {
+                        entryToAdd.ctxtForTranslator = ctxtForTranslator;
                     }
 
                     store.add(entryToAdd);

--- a/src/parsers/nunjucksjs.js
+++ b/src/parsers/nunjucksjs.js
@@ -27,19 +27,19 @@ export default function parseAndExtract(source, filepath, markers, store) {
                 // make sure we are in a gettext or translation function
                 if (path.node.arguments[1]) {
                     const lineno = path.parent.expressions[0].right.value;
-                    let msgid, msgctxt, msgid_plural;
+                    let msgid, ctxtForTranslator, msgid_plural;
                     if (path.node.arguments[1].value === '_') {
                         // singular case
                         msgid = path.node.arguments[2].elements[0].value;
                         if (path.node.arguments[2].elements[1] && path.node.arguments[2].elements[1].type === 'StringLiteral') {
-                            msgctxt = path.node.arguments[2].elements[1].value;
+                            ctxtForTranslator = path.node.arguments[2].elements[1].value;
                         }
                     } else if (path.node.arguments[1].value === 'ngettext') {
                         // plural case
                         msgid = path.node.arguments[2].elements[0].value;
                         msgid_plural = path.node.arguments[2].elements[1].value;
                         if (path.node.arguments[2].elements[2] && path.node.arguments[2].elements[2].type === 'StringLiteral') {
-                            msgctxt = path.node.arguments[2].elements[2].value;
+                            ctxtForTranslator = path.node.arguments[2].elements[2].value;
                         }
                     } else {
                         return;
@@ -55,8 +55,8 @@ export default function parseAndExtract(source, filepath, markers, store) {
                     if (msgid_plural) {
                         entryToAdd.msgid_plural = msgid_plural;
                     }
-                    if (msgctxt) {
-                        entryToAdd.msgctxt = msgctxt;
+                    if (ctxtForTranslator) {
+                        entryToAdd.ctxtForTranslator = ctxtForTranslator;
                     }
 
                     store.add(entryToAdd);

--- a/src/writePo.js
+++ b/src/writePo.js
@@ -13,11 +13,11 @@ export default function(input, options) {
                         .join('\n');
 
         let contextObj;
-        if (entry.msgctxt) {
-            if (!translationObj['translations'][entry.msgctxt]) {
-                translationObj['translations'][entry.msgctxt ] = {};
+        if (entry.ctxtForTranslator) {
+            if (!translationObj['translations'][entry.ctxtForTranslator]) {
+                translationObj['translations'][entry.ctxtForTranslator ] = {};
             }
-            contextObj = translationObj['translations'][entry.msgctxt];
+            contextObj = translationObj['translations'][entry.ctxtForTranslator];
         } else {
             contextObj = translationObj['translations'][''];
         }
@@ -28,7 +28,7 @@ export default function(input, options) {
             msgid_plural: entry.msgid_plural,
             msgstr: entry.msgid_plural ? ['', ''] : '',
             comments: {
-                translator: entry.msgctxt,
+                translator: entry.ctxtForTranslator,
                 reference
             }
         };

--- a/src/writePo.js
+++ b/src/writePo.js
@@ -23,11 +23,11 @@ export default function(input, options) {
         }
 
         contextObj[entry.msgid] = {
-            msgctxt: entry.msgctxt,
+            '#.': entry.msgctxt,
+            '#:': {reference},
             msgid: entry.msgid,
             msgid_plural: entry.msgid_plural,
-            msgstr: entry.msgid_plural ? ['', ''] : '',
-            comments: {reference}
+            msgstr: entry.msgid_plural ? ['', ''] : ''
         };
     });
 

--- a/src/writePo.js
+++ b/src/writePo.js
@@ -23,11 +23,14 @@ export default function(input, options) {
         }
 
         contextObj[entry.msgid] = {
-            '#.': entry.msgctxt,
-            '#:': {reference},
+            msgctxt: '',
             msgid: entry.msgid,
             msgid_plural: entry.msgid_plural,
-            msgstr: entry.msgid_plural ? ['', ''] : ''
+            msgstr: entry.msgid_plural ? ['', ''] : '',
+            comments: {
+                translator: entry.msgctxt,
+                reference
+            }
         };
     });
 

--- a/test/buildOutput.js
+++ b/test/buildOutput.js
@@ -12,7 +12,7 @@ function buildOutput(path, data) {
             })
         };
         if (split[1]) {
-            output.msgctxt = split[1];
+            output.ctxtForTranslator = split[1];
         }
         return output;
     });

--- a/test/po/test.js
+++ b/test/po/test.js
@@ -38,7 +38,7 @@ describe('xtractor.writePo(), xtractor.parsePo()', function() {
             },
             {
                 msgid: 'Safe mode alert!',
-                msgctxt: 'settings',
+                ctxtForTranslator: 'settings',
                 loc: [
                     {
                         path: __dirname + '/fixture.js',
@@ -70,7 +70,7 @@ msgid "Safe mode alert!"
 msgstr ""
 
 #: ${__dirname}/fixture.js:13
-msgctxt "settings"
+ctxtForTranslator "settings"
 msgid "Safe mode alert!"
 msgstr ""`;
 
@@ -109,7 +109,7 @@ msgstr ""`;
         msgstr "d"
 
         #: ${__dirname}/fixture.js:13
-        msgctxt "settings"
+        ctxtForTranslator "settings"
         msgid "Safe mode alert!"
         msgstr "e"`;
 


### PR DESCRIPTION
Should fix issue with gettext-parser not recognizing context and path provided in our strings. https://github.com/smhg/gettext-parser

I think the `msgctxt` param should be used for letting Smartling know a string is a variant rather than for translator context. https://docs.smartling.com/pages/supported-file-types/Gettext-PO-POT/